### PR TITLE
[WIP] Session Tracking

### DIFF
--- a/drivers/dockerExecDriver.js
+++ b/drivers/dockerExecDriver.js
@@ -6,6 +6,11 @@ var events = require('events');
 var eventEmitter = new events.EventEmitter();
 var found = false;
 
+module.exports = {
+  connect: connect,
+  remove: remove
+};
+
 which('docker', function(err, cmdpath) {
   if (err) {
     console.log('err finding docker '+err);
@@ -16,26 +21,66 @@ which('docker', function(err, cmdpath) {
   eventEmitter.emit('connected');
 });
 
+/**
+ * Holds a list of terminals by uuid. This allows us to reconnect to existing
+ * terminals in the case of a connection drop, or if we just want to keep the
+ * bash terminals around so they can be reloaded at a later time.
+ * @type Object
+ */
+var terminalSessions = {};
+
 // pid of container to connect to *REQUIRED
 // Args are argument for docker-enter.
 // docker enter is a script which just needs docker containerId
-var connect = function(nsArgs, streamOpts, cb) {
+function connect (nsArgs, streamOpts, cb) {
+  // We cannot connect a terminal unless we know the exact container id
   if(!nsArgs.containerId) {
     return null;
   }
+
+  // Optional session UUID to allow for reconnects to exisiting terminal
+  // sessions.
+  var uuid = nsArgs.sessionUUID;
+
+  // Get the terminal for the connection request
   if (!found) {
     return eventEmitter.on('found', function() {
-      spawnTerm();
+      getTerm();
     });
   }
+  getTerm();
 
-  spawnTerm();
+  function getTerm() {
+    // Look for an exisiting terminal given a session uuid
+    if (uuid && terminalSessions[uuid]) {
+      return cb(null, terminalSessions[uuid]);
+    }
+
+    // Otherwise, spawn a new terminal
+    spawnTerm();
+  }
 
   function spawnTerm() {
     var cmd = dockerPath + ' exec -it ' + nsArgs.containerId + ' bash';
     var term = pty.spawn('bash', ['-c', cmd], streamOpts);
-    cb(null, term);
+
+    // If we were provided a uuid, map the new terminal to that uuid
+    if (uuid) {
+      term._session_uuid = uuid;
+      terminalSessions[uuid] = term;
+    }
+
+    return cb(null, term);
   }
 };
 
-module.exports.connect = connect;
+/**
+ * Removes and closes a terminal session with the given uuid.
+ * @param {String} uuid Unique identifier for the terminal session.
+ */
+function remove (uuid) {
+  var terminal = terminalSessions[uuid];
+  if (!terminal) { return; }
+  delete terminalSessions[uuid];
+  terminal.kill();
+}

--- a/lib/filibuster.js
+++ b/lib/filibuster.js
@@ -1,6 +1,6 @@
 'use strict';
 require('./loadenv.js')();
-var term = require('../drivers/'+process.env.NSTYPE+'.js');
+var term = require('../drivers/' + process.env.NSTYPE + '.js');
 var Primus = require('primus');
 var express = require('express');
 var http = require('http');
@@ -134,6 +134,7 @@ function setupClientStream(clientEventsStream, terminal)  {
       });
       return console.log('invalid input:', message);
     }
+
     if(message.event === 'resize') {
       if(typeof message.data !== 'object' ||
         typeof message.data.x !== 'number' ||
@@ -145,15 +146,45 @@ function setupClientStream(clientEventsStream, terminal)  {
         return console.log("invalid x and y data", message);
       }
       return terminal.resize(message.data.x, message.data.y);
-    } else if (message.event === 'ping') {
+    }
+
+    if (message.event === 'ping') {
       return clientEventsStream.write({
         event: "pong"
       });
     }
+
+    if (message.event === 'end_session') {
+      if (!term.remove) {
+        clientEventStream.write({
+          event: 'error',
+          data: 'driver does not support end_session'
+        });
+        return console.log('Terminal driver does not have .remove');
+      }
+
+      if (typeof message.data !== 'object' || !message.data.sessionUUID) {
+        clientEventStream.write({
+          event: 'error',
+          data: 'end_session event requires data.sessionUUID'
+        });
+        return console.log('end_session event not provided with uuid');
+      }
+
+      term.remove(message.data.sessionUUID);
+      return clientEventStream.write({
+        event: 'session_removed',
+        data: {
+          sessionUUID: message.data.sessionUUID
+        }
+      });
+    }
+
     clientEventsStream.write({
       event: "error",
       data: "event not supported"
     });
+    
     return console.log("event not supported: ", message.event);
   });
   clientEventsStream.write({


### PR DESCRIPTION
This modifies filibuster so that it keeps track terminal sessions via a uuid. Clients can send this uuid upon connection to reconnect to an existing terminal process. 

I modified the driver in the following ways:

* The driver now keeps a map of unique ids to `pty.js` terminals
* Connect now looks for `sessionUUID` in the `nsArgs`, if present and a terminal with that id exists it will send that terminal back instead of creating a new one
* If no such terminal was mapped to the given uuid, the `spawnTerminal` method will assign the newly created terminal to that uuid in the map
* Finally, we expose a new method named `remove` which takes a uuid and will remove a terminal mapping to that id from the map and kill the pty process

Furthermore, I modified `lib/filibuster.js` to listen for a new event named `end_session`. Given a terminal uuid this will call the driver's `remove` method with the given uuid in the event data. Upon success it returns a `session_removed` event back to the client.

This is a work in progress, but the basic concepts are in place. Please review and ask questions.